### PR TITLE
csv: handle nil value for column

### DIFF
--- a/formats/csv.go
+++ b/formats/csv.go
@@ -55,6 +55,10 @@ func (f *CsvFormat) WriteRow(values map[string]interface{}) error {
 			} else {
 				record = append(record, "false")
 			}
+		case nil:
+			record = append(record, "")
+		default:
+			return fmt.Errorf("column type(%T) not supported", value)
 		}
 	}
 	err := f.writer.Write(record)


### PR DESCRIPTION
In csv format, empty columns should be considered and exported as
nothing between two delimiters.